### PR TITLE
Sync waiting ports with upstream projects

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "${ARTEMIS_SERVER_PORT}:8080"
     environment:
-      - WAIT_FOR="db:3306,gitlab:80"
+      - WAIT_FOR="gitlab:80"
       - PROFILES=${ARTEMIS_SPRING_PROFILES}
     volumes:
       - ${ARTEMIS_CONFIG_DIR}:/opt/Artemis/config


### PR DESCRIPTION
Remove db from waiting as http code (see server project) will not work for mysql port.